### PR TITLE
lx::cipher: Change to byte arrays instead of strings

### DIFF
--- a/examples/decrypt-lx-file.rs
+++ b/examples/decrypt-lx-file.rs
@@ -9,10 +9,10 @@ fn main() -> anyhow::Result<()> {
     };
 
     let path = PathBuf::from(path);
-    let content = std::fs::read_to_string(&path)?;
+    let content = std::fs::read(&path)?;
 
     let xml_path = path.with_extension("xml");
-    let decrypted = flarmnet::lx::cipher::decrypt(&content)?;
+    let decrypted = flarmnet::lx::cipher::decrypt(&content);
     std::fs::write(&xml_path, &decrypted)?;
 
     Ok(())

--- a/src/lx/cipher.rs
+++ b/src/lx/cipher.rs
@@ -1,13 +1,9 @@
-use std::string::FromUtf8Error;
-
-pub fn decrypt(s: &str) -> Result<String, FromUtf8Error> {
-    let bytes: Vec<_> = s.bytes().map(|b| b.wrapping_sub(1)).collect();
-    String::from_utf8(bytes)
+pub fn decrypt(s: &[u8]) -> Vec<u8> {
+    s.iter().map(|b| b.wrapping_sub(1)).collect()
 }
 
-pub fn encrypt(s: &str) -> Result<String, FromUtf8Error> {
-    let bytes: Vec<_> = s.bytes().map(|b| b.wrapping_add(1)).collect();
-    String::from_utf8(bytes)
+pub fn encrypt(s: &[u8]) -> Vec<u8> {
+    s.iter().map(|b| b.wrapping_add(1)).collect()
 }
 
 #[cfg(test)]
@@ -17,16 +13,16 @@ mod tests {
     #[test]
     fn decryption_works() {
         assert_eq!(
-            decrypt("=@ynm!wfstjpo>#2/1#!fodpejoh>#VUG.9#@?=GMBSNOFU!Wfstjpo>#11:44f#?=GMBSNEBUB!GmbsnJE>#111111#?").unwrap(),
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<FLARMNET Version=\"00933e\">\n<FLARMDATA FlarmID=\"000000\">\n"
+            decrypt(b"=@ynm!wfstjpo>#2/1#!fodpejoh>#VUG.9#@?=GMBSNOFU!Wfstjpo>#11:44f#?=GMBSNEBUB!GmbsnJE>#111111#?"),
+            b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<FLARMNET Version=\"00933e\">\n<FLARMDATA FlarmID=\"000000\">\n"
         );
     }
 
     #[test]
     fn encryption_works() {
         assert_eq!(
-            encrypt("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<FLARMNET Version=\"00933e\">\n<FLARMDATA FlarmID=\"000000\">\n").unwrap(),
-            "=@ynm!wfstjpo>#2/1#!fodpejoh>#VUG.9#@?=GMBSNOFU!Wfstjpo>#11:44f#?=GMBSNEBUB!GmbsnJE>#111111#?"
+            encrypt(b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<FLARMNET Version=\"00933e\">\n<FLARMDATA FlarmID=\"000000\">\n"),
+            b"=@ynm!wfstjpo>#2/1#!fodpejoh>#VUG.9#@?=GMBSNOFU!Wfstjpo>#11:44f#?=GMBSNEBUB!GmbsnJE>#111111#?"
         );
     }
 }

--- a/src/lx/encode.rs
+++ b/src/lx/encode.rs
@@ -89,7 +89,7 @@ pub fn encode_file(file: &File) -> Result<String, EncodeError> {
     }
     writer.write_event(Event::End(BytesEnd::borrowed(b"FLARMNET")))?;
 
-    let xml = String::from_utf8(writer.into_inner().into_inner())?;
+    let xml = writer.into_inner().into_inner();
 
-    Ok(encrypt(&xml)?)
+    Ok(String::from_utf8(encrypt(&xml))?)
 }


### PR DESCRIPTION
because we don't care whether it's valid uft8 or not at this point, and there is no need to return a `Result`