### PR TITLE
lx::encode: Skip escaping for static text

### DIFF
--- a/src/lx/encode.rs
+++ b/src/lx/encode.rs
@@ -61,60 +61,60 @@ impl<W: Write> Writer<W> {
         let writer = &mut self.xml_writer;
 
         writer.write_event(Event::Decl(BytesDecl::new(b"1.0", Some(b"UTF-8"), None)))?;
-        writer.write_event(Event::Text(BytesText::from_plain_str("\n")))?;
+        writer.write_event(Event::Text(BytesText::from_escaped(b"\n" as &[u8])))?;
 
         let version = format!("{:06x?}", file.version);
         writer.write_event(Event::Start(
             BytesStart::borrowed_name(b"FLARMNET")
                 .with_attributes(vec![("Version".as_bytes(), version.as_bytes())]),
         ))?;
-        writer.write_event(Event::Text(BytesText::from_plain_str("\n")))?;
+        writer.write_event(Event::Text(BytesText::from_escaped(b"\n" as &[u8])))?;
 
         for record in &file.records {
             writer.write_event(Event::Start(
                 BytesStart::borrowed_name(b"FLARMDATA")
                     .with_attributes(vec![("FlarmID".as_bytes(), record.flarm_id.as_bytes())]),
             ))?;
-            writer.write_event(Event::Text(BytesText::from_plain_str("\n")))?;
+            writer.write_event(Event::Text(BytesText::from_escaped(b"\n" as &[u8])))?;
 
-            writer.write_event(Event::Text(BytesText::from_plain_str("\t")))?;
+            writer.write_event(Event::Text(BytesText::from_escaped(b"\t" as &[u8])))?;
             writer.write_event(Event::Start(BytesStart::borrowed_name(b"NAME")))?;
             writer.write_event(Event::Text(BytesText::from_plain_str(&record.pilot_name)))?;
             writer.write_event(Event::End(BytesEnd::borrowed(b"NAME")))?;
-            writer.write_event(Event::Text(BytesText::from_plain_str("\n")))?;
+            writer.write_event(Event::Text(BytesText::from_escaped(b"\n" as &[u8])))?;
 
-            writer.write_event(Event::Text(BytesText::from_plain_str("\t")))?;
+            writer.write_event(Event::Text(BytesText::from_escaped(b"\t" as &[u8])))?;
             writer.write_event(Event::Start(BytesStart::borrowed_name(b"AIRFIELD")))?;
             writer.write_event(Event::Text(BytesText::from_plain_str(&record.airfield)))?;
             writer.write_event(Event::End(BytesEnd::borrowed(b"AIRFIELD")))?;
-            writer.write_event(Event::Text(BytesText::from_plain_str("\n")))?;
+            writer.write_event(Event::Text(BytesText::from_escaped(b"\n" as &[u8])))?;
 
-            writer.write_event(Event::Text(BytesText::from_plain_str("\t")))?;
+            writer.write_event(Event::Text(BytesText::from_escaped(b"\t" as &[u8])))?;
             writer.write_event(Event::Start(BytesStart::borrowed_name(b"TYPE")))?;
             writer.write_event(Event::Text(BytesText::from_plain_str(&record.plane_type)))?;
             writer.write_event(Event::End(BytesEnd::borrowed(b"TYPE")))?;
-            writer.write_event(Event::Text(BytesText::from_plain_str("\n")))?;
+            writer.write_event(Event::Text(BytesText::from_escaped(b"\n" as &[u8])))?;
 
-            writer.write_event(Event::Text(BytesText::from_plain_str("\t")))?;
+            writer.write_event(Event::Text(BytesText::from_escaped(b"\t" as &[u8])))?;
             writer.write_event(Event::Start(BytesStart::borrowed_name(b"REG")))?;
             writer.write_event(Event::Text(BytesText::from_plain_str(&record.registration)))?;
             writer.write_event(Event::End(BytesEnd::borrowed(b"REG")))?;
-            writer.write_event(Event::Text(BytesText::from_plain_str("\n")))?;
+            writer.write_event(Event::Text(BytesText::from_escaped(b"\n" as &[u8])))?;
 
-            writer.write_event(Event::Text(BytesText::from_plain_str("\t")))?;
+            writer.write_event(Event::Text(BytesText::from_escaped(b"\t" as &[u8])))?;
             writer.write_event(Event::Start(BytesStart::borrowed_name(b"COMPID")))?;
             writer.write_event(Event::Text(BytesText::from_plain_str(&record.call_sign)))?;
             writer.write_event(Event::End(BytesEnd::borrowed(b"COMPID")))?;
-            writer.write_event(Event::Text(BytesText::from_plain_str("\n")))?;
+            writer.write_event(Event::Text(BytesText::from_escaped(b"\n" as &[u8])))?;
 
-            writer.write_event(Event::Text(BytesText::from_plain_str("\t")))?;
+            writer.write_event(Event::Text(BytesText::from_escaped(b"\t" as &[u8])))?;
             writer.write_event(Event::Start(BytesStart::borrowed_name(b"FREQUENCY")))?;
             writer.write_event(Event::Text(BytesText::from_plain_str(&record.frequency)))?;
             writer.write_event(Event::End(BytesEnd::borrowed(b"FREQUENCY")))?;
-            writer.write_event(Event::Text(BytesText::from_plain_str("\n")))?;
+            writer.write_event(Event::Text(BytesText::from_escaped(b"\n" as &[u8])))?;
 
             writer.write_event(Event::End(BytesEnd::borrowed(b"FLARMDATA")))?;
-            writer.write_event(Event::Text(BytesText::from_plain_str("\n")))?;
+            writer.write_event(Event::Text(BytesText::from_escaped(b"\n" as &[u8])))?;
         }
         writer.write_event(Event::End(BytesEnd::borrowed(b"FLARMNET")))?;
 


### PR DESCRIPTION
This is only whitespace so there is no need for escaping and the UTF8 conversion call.