### PR TITLE
Update quick-xml to 0.38.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
  "encoding_rs",
  "insta",
  "minidom",
- "quick-xml 0.30.0",
+ "quick-xml 0.38.4",
  "thiserror",
 ]
 
@@ -219,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.30.0"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ xcsoar = ["encoding_rs"]
 [dependencies]
 encoding_rs = { version = "0.8.34", optional = true }
 minidom = { version = "0.12.0", optional = true }
-quick-xml = { version = "0.30.0", optional = true }
+quick-xml = { version = "0.38.0", optional = true }
 thiserror = "1.0.59"
 
 [dev-dependencies]

--- a/src/lx/encode.rs
+++ b/src/lx/encode.rs
@@ -9,6 +9,8 @@ use thiserror::Error;
 pub enum EncodeError {
     #[error(transparent)]
     Xml(#[from] quick_xml::Error),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
 }
 
 /// Encodes a FlarmNet file in LX format.


### PR DESCRIPTION
## Summary
- Updated quick-xml dependency from 0.30.0 to 0.38.0
- Added `std::io::Error` variant to `EncodeError` enum in `src/lx/encode.rs` to handle API changes in quick-xml 0.38.0 where `write_event` now returns `io::Error` instead of `quick_xml::Error`

## Test plan
- [x] All existing unit tests pass (19 tests)
- [x] All doc tests pass (5 tests)
- [x] Build succeeds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)