### PR TITLE
Update minimum Rust toolchain version to 1.91.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,4 +45,4 @@ jobs:
       - run: rustup set profile minimal
       - run: rustup show
       - run: rustup component add clippy
-      - run: cargo clippy -- --deny warnings --allow clippy::unknown-clippy-lints
+      - run: cargo clippy -- --deny warnings --allow unknown-lints

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/glide-rs/flarmnet-rs.git"
 keywords = ["flarm", "flarmnet", "ogn", "glider", "gliding"]
 edition = "2018"
+rust-version = "1.91.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Tobias Bieniek <tobias.bieniek@gmail.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/glide-rs/flarmnet-rs.git"
 keywords = ["flarm", "flarmnet", "ogn", "glider", "gliding"]
-edition = "2018"
+edition = "2024"
 rust-version = "1.91.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.71.1"
+channel = "1.91.0"

--- a/src/lx/cipher.rs
+++ b/src/lx/cipher.rs
@@ -13,11 +13,10 @@ impl<R: Read> Reader<R> {
 
 impl<R: Read> Read for Reader<R> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.inner.read(buf).map(|result| {
+        self.inner.read(buf).inspect(|_| {
             for byte in buf.iter_mut() {
                 *byte = byte.wrapping_sub(1);
             }
-            result
         })
     }
 }

--- a/src/lx/decode.rs
+++ b/src/lx/decode.rs
@@ -1,6 +1,6 @@
-use crate::lx::cipher;
 use crate::Record;
-use minidom::{quick_xml, Element, NSChoice};
+use crate::lx::cipher;
+use minidom::{Element, NSChoice, quick_xml};
 use std::io::BufReader;
 use thiserror::Error;
 

--- a/src/lx/encode.rs
+++ b/src/lx/encode.rs
@@ -1,5 +1,5 @@
-use crate::lx::cipher;
 use crate::File;
+use crate::lx::cipher;
 use quick_xml;
 use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
 use std::io::{Cursor, Write};

--- a/src/tdb/decode.rs
+++ b/src/tdb/decode.rs
@@ -1,6 +1,5 @@
 use super::consts::*;
 use crate::Record;
-use std::convert::TryInto;
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/src/tdb/encode.rs
+++ b/src/tdb/encode.rs
@@ -85,20 +85,12 @@ impl<W: Write> Writer<W> {
 fn write_string(buf: &mut [u8; RECORD_SIZE], offset: usize, value: &str) {
     let max_content = STRING_FIELD_SIZE - 1;
     let truncated = if value.len() > max_content {
-        &value[..floor_char_boundary(value, max_content)]
+        &value[..value.floor_char_boundary(max_content)]
     } else {
         value
     };
     buf[offset..offset + truncated.len()].copy_from_slice(truncated.as_bytes());
     // remaining bytes are already zero from initialization
-}
-
-fn floor_char_boundary(s: &str, index: usize) -> usize {
-    let mut i = index;
-    while !s.is_char_boundary(i) {
-        i -= 1;
-    }
-    i
 }
 
 fn parse_flarm_id(s: &str) -> Result<u32, EncodeError> {


### PR DESCRIPTION
Rust 1.91.0 is already old enough to use it as an MSRV, so let's do that.